### PR TITLE
Update AzureDocumentDbEventStore.cs

### DIFF
--- a/Framework/Azure/Cqrs.Azure.DocumentDb/Events/AzureDocumentDbEventStore.cs
+++ b/Framework/Azure/Cqrs.Azure.DocumentDb/Events/AzureDocumentDbEventStore.cs
@@ -54,8 +54,9 @@ namespace Cqrs.Azure.DocumentDb.Events
 			{
 				Database database = AzureDocumentDbHelper.CreateOrReadDatabase(client, AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionDatabaseName()).Result;
 				//DocumentCollection collection = AzureDocumentDbHelper.CreateOrReadCollection(client, database, string.Format("{0}_{1}", AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionCollectionName(), typeof(T).FullName)).Result;
-				string collectionName = string.Format("{0}", AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionCollectionName());
-				DocumentCollection collection = AzureDocumentDbHelper.CreateOrReadCollection(client, database, collectionName, UniqueIndexProperties).Result;
+				//string collectionName = string.Format("{0}", AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionCollectionName());
+				string collectionName = string.Format("{0}::{1}", AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionCollectionName(), aggregateRootType.FullName);
+                		DocumentCollection collection = AzureDocumentDbHelper.CreateOrReadCollection(client, database, collectionName, UniqueIndexProperties).Result;
 
 				IOrderedQueryable<EventData> query = client.CreateDocumentQuery<EventData>(collection.SelfLink);
 				string streamName = string.Format(CqrsEventStoreStreamNamePattern, aggregateRootType.FullName, aggregateId);

--- a/Framework/Azure/Cqrs.Azure.DocumentDb/Events/AzureDocumentDbEventStore.cs
+++ b/Framework/Azure/Cqrs.Azure.DocumentDb/Events/AzureDocumentDbEventStore.cs
@@ -78,8 +78,9 @@ namespace Cqrs.Azure.DocumentDb.Events
 			{
 				Database database = AzureDocumentDbHelper.CreateOrReadDatabase(client, AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionDatabaseName()).Result;
 				//DocumentCollection collection = AzureDocumentDbHelper.CreateOrReadCollection(client, database, string.Format("{0}_{1}", AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionCollectionName(), typeof(T).FullName)).Result;
-				string collectionName = string.Format("{0}", AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionCollectionName());
-				DocumentCollection collection = AzureDocumentDbHelper.CreateOrReadCollection(client, database, collectionName, UniqueIndexProperties).Result;
+				//string collectionName = string.Format("{0}", AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionCollectionName());
+				string collectionName = string.Format("{0}::{1}", AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionCollectionName(), aggregateRootType.FullName);
+                		DocumentCollection collection = AzureDocumentDbHelper.CreateOrReadCollection(client, database, collectionName, UniqueIndexProperties).Result;
 
 				IOrderedQueryable<EventData> query = client.CreateDocumentQuery<EventData>(collection.SelfLink);
 

--- a/Framework/Azure/Cqrs.Azure.DocumentDb/Events/AzureDocumentDbEventStore.cs
+++ b/Framework/Azure/Cqrs.Azure.DocumentDb/Events/AzureDocumentDbEventStore.cs
@@ -78,9 +78,8 @@ namespace Cqrs.Azure.DocumentDb.Events
 			{
 				Database database = AzureDocumentDbHelper.CreateOrReadDatabase(client, AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionDatabaseName()).Result;
 				//DocumentCollection collection = AzureDocumentDbHelper.CreateOrReadCollection(client, database, string.Format("{0}_{1}", AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionCollectionName(), typeof(T).FullName)).Result;
-				//string collectionName = string.Format("{0}", AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionCollectionName());
-				string collectionName = string.Format("{0}::{1}", AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionCollectionName(), aggregateRootType.FullName);
-                		DocumentCollection collection = AzureDocumentDbHelper.CreateOrReadCollection(client, database, collectionName, UniqueIndexProperties).Result;
+				string collectionName = string.Format("{0}", AzureDocumentDbEventStoreConnectionStringFactory.GetEventStoreConnectionCollectionName());
+				DocumentCollection collection = AzureDocumentDbHelper.CreateOrReadCollection(client, database, collectionName, UniqueIndexProperties).Result;
 
 				IOrderedQueryable<EventData> query = client.CreateDocumentQuery<EventData>(collection.SelfLink);
 


### PR DESCRIPTION
The collection name created in event store is [CollectionName]::[AggregateType] where as while fetching we are not using the same format but just collection name. Hence the get is not returning the existing aggregate