### PR TITLE
* Documented all of the Ninject packages/projects.

### DIFF
--- a/Framework/Azure/Cqrs.Azure.DocumentDb/Cqrs.Azure.DocumentDb.nuspec
+++ b/Framework/Azure/Cqrs.Azure.DocumentDb/Cqrs.Azure.DocumentDb.nuspec
@@ -15,7 +15,7 @@
 		<releaseNotes>
 			Version 2.0
 
-			* Added configurable setting "Cqrs.Azure.DocumentDb.UseOneCollectionPerDataStore" to enable control over the use of a single collection (cheaper) for all data stores or one collection per data store (more flexible). The default value is true.
+			* Added configurable setting "Cqrs.Azure.DocumentDb.UseSingleCollectionForAllDataStores" to enable control over the use of a single collection (cheaper) for all data stores or one collection per data store (more flexible). The default value is true.
 		</releaseNotes>
 		<dependencies>
 			<dependency id="Cqrs" version="[$version$]" />

--- a/Framework/Azure/Cqrs.Azure.DocumentDb/Factories/AzureDocumentDbDataStoreConnectionStringFactory.cs
+++ b/Framework/Azure/Cqrs.Azure.DocumentDb/Factories/AzureDocumentDbDataStoreConnectionStringFactory.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using cdmdotnet.Logging;
 using Cqrs.Configuration;
+using Cqrs.DataStores;
+using Cqrs.Entities;
 using Microsoft.Azure.Documents.Client;
 
 namespace Cqrs.Azure.DocumentDb.Factories
@@ -40,10 +42,14 @@ namespace Cqrs.Azure.DocumentDb.Factories
 			return ConfigurationManager.GetSetting("Cqrs.Azure.DocumentDb.CollectionName") ?? "CqrsDataStore";
 		}
 
-		public virtual bool UseOneCollectionPerDataStore()
+		/// <summary>
+		/// Indicates if a different collection should be used per <see cref="IEntity"/>/<see cref="IDataStore{TData}"/> or a single collection used for all instances of <see cref="IDataStore{TData}"/> and <see cref="IDataStore{TData}"/>.
+		/// Setting this to true can become expensive as each <see cref="IEntity"/> will have it's own collection. Check the relevant SDK/pricing models.
+		/// </summary>
+		public virtual bool UseSingleCollectionForAllDataStores()
 		{
 			bool value;
-			if (!bool.TryParse(ConfigurationManager.GetSetting("Cqrs.Azure.DocumentDb.UseOneCollectionPerDataStore"), out value))
+			if (!bool.TryParse(ConfigurationManager.GetSetting("Cqrs.Azure.DocumentDb.UseSingleCollectionForAllDataStores"), out value))
 				value = true;
 			return value;
 		}

--- a/Framework/Azure/Cqrs.Azure.DocumentDb/Factories/AzureDocumentDbDataStoreFactory.cs
+++ b/Framework/Azure/Cqrs.Azure.DocumentDb/Factories/AzureDocumentDbDataStoreFactory.cs
@@ -41,7 +41,7 @@ namespace Cqrs.Azure.DocumentDb.Factories
 
 		protected virtual DocumentCollection GetCollection<TEntity>(DocumentClient client, Database database)
 		{
-			string collectionName = string.Format(AzureDocumentDbDataStoreConnectionStringFactory.UseOneCollectionPerDataStore() ? "{0}" : "{0}_{1}", AzureDocumentDbDataStoreConnectionStringFactory.GetAzureDocumentDbCollectionName(), typeof(TEntity).FullName);
+			string collectionName = string.Format(AzureDocumentDbDataStoreConnectionStringFactory.UseSingleCollectionForAllDataStores() ? "{0}" : "{0}_{1}", AzureDocumentDbDataStoreConnectionStringFactory.GetAzureDocumentDbCollectionName(), typeof(TEntity).FullName);
 			DocumentCollection collection = AzureDocumentDbHelper.CreateOrReadCollection(client, database, collectionName).Result;
 
 			return collection;

--- a/Framework/Azure/Cqrs.Azure.DocumentDb/Factories/IAzureDocumentDbDataStoreConnectionStringFactory.cs
+++ b/Framework/Azure/Cqrs.Azure.DocumentDb/Factories/IAzureDocumentDbDataStoreConnectionStringFactory.cs
@@ -6,6 +6,8 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using Cqrs.DataStores;
+using Cqrs.Entities;
 using Microsoft.Azure.Documents.Client;
 
 namespace Cqrs.Azure.DocumentDb.Factories
@@ -18,6 +20,10 @@ namespace Cqrs.Azure.DocumentDb.Factories
 
 		string GetAzureDocumentDbCollectionName();
 
-		bool UseOneCollectionPerDataStore();
+		/// <summary>
+		/// Indicates if a different collection should be used per <see cref="IEntity"/>/<see cref="IDataStore{TData}"/> or a single collection used for all instances of <see cref="IDataStore{TData}"/> and <see cref="IDataStore{TData}"/>.
+		/// Setting this to true can become expensive as each <see cref="IEntity"/> will have it's own collection. Check the relevant SDK/pricing models.
+		/// </summary>
+		bool UseSingleCollectionForAllDataStores();
 	}
 }

--- a/Framework/Cqrs.MongoDB/Events/IMongoDbEventStoreConnectionStringFactory.cs
+++ b/Framework/Cqrs.MongoDB/Events/IMongoDbEventStoreConnectionStringFactory.cs
@@ -6,12 +6,23 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using Cqrs.Events;
+
 namespace Cqrs.MongoDB.Events
 {
+	/// <summary>
+	/// A factory for getting connection strings and database names for <see cref="IEventStore{TAuthenticationToken}"/> access.
+	/// </summary>
 	public interface IMongoDbEventStoreConnectionStringFactory
 	{
+		/// <summary>
+		/// Gets the current connection string.
+		/// </summary>
 		string GetEventStoreConnectionString();
 
+		/// <summary>
+		/// Gets the current database name.
+		/// </summary>
 		string GetEventStoreDatabaseName();
 	}
 }

--- a/Framework/Cqrs.MongoDB/Factories/IMongoDbDataStoreConnectionStringFactory.cs
+++ b/Framework/Cqrs.MongoDB/Factories/IMongoDbDataStoreConnectionStringFactory.cs
@@ -6,12 +6,23 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using Cqrs.DataStores;
+
 namespace Cqrs.MongoDB.Factories
 {
+	/// <summary>
+	/// A factory for getting connection strings and database names for <see cref="IDataStore{TData}"/> access.
+	/// </summary>
 	public interface IMongoDbDataStoreConnectionStringFactory
 	{
+		/// <summary>
+		/// Gets the current connection string.
+		/// </summary>
 		string GetDataStoreConnectionString();
 
+		/// <summary>
+		/// Gets the current database name.
+		/// </summary>
 		string GetDataStoreDatabaseName();
 	}
 }

--- a/Framework/Cqrs.MongoDB/Factories/MongoDbDataStoreConnectionStringFactory.cs
+++ b/Framework/Cqrs.MongoDB/Factories/MongoDbDataStoreConnectionStringFactory.cs
@@ -10,10 +10,14 @@ using System;
 using System.Configuration;
 using Cqrs.Configuration;
 using cdmdotnet.Logging;
+using Cqrs.DataStores;
 using Cqrs.Exceptions;
 
 namespace Cqrs.MongoDB.Factories
 {
+	/// <summary>
+	/// A factory for getting connection strings and database names for <see cref="IDataStore{TData}"/> access.
+	/// </summary>
 	public class MongoDbDataStoreConnectionStringFactory : IMongoDbDataStoreConnectionStringFactory
 	{
 		public static string MongoDbConnectionStringKey = "Cqrs.MongoDb.DataStore.ConnectionStringName";

--- a/Framework/Cqrs.Ninject.ServiceHost/Cqrs.Ninject.ServiceHost.csproj
+++ b/Framework/Cqrs.Ninject.ServiceHost/Cqrs.Ninject.ServiceHost.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.ServiceHost.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.ServiceHost.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">

--- a/Framework/Cqrs.Ninject.ServiceHost/NinjectWcfServiceHostFactory.cs
+++ b/Framework/Cqrs.Ninject.ServiceHost/NinjectWcfServiceHostFactory.cs
@@ -6,8 +6,18 @@ using Ninject.Extensions.Wcf;
 
 namespace Cqrs.Ninject.ServiceHost
 {
+	/// <summary>
+	/// A <see cref="NinjectServiceHostFactory"/> suitable for use with WCF.
+	/// </summary>
+	/// <typeparam name="TServiceType">The <see cref="Type"/> of the WCF service contract.</typeparam>
 	public class NinjectWcfServiceHostFactory<TServiceType> : NinjectServiceHostFactory
 	{
+		/// <summary>
+		/// Creates a <see cref="System.ServiceModel.ServiceHost"/> for a specified type of service with a specific base address.
+		/// </summary>
+		/// <param name="serviceType">Specifies the <see cref="Type"/> of service to host.</param>
+		/// <param name="baseAddresses">The <see cref="System.Array"/> of type <see cref="System.Uri"/> that contains the base addresses for the service hosted.</param>
+		/// <returns>A <see cref="System.ServiceModel.ServiceHost"/> for the type of service specified with a specific base address.</returns>
 		protected override System.ServiceModel.ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses)
 		{
 			System.ServiceModel.ServiceHost host = base.CreateServiceHost(serviceType, baseAddresses);

--- a/Framework/Cqrs.Web.Mvc/Cqrs.Web.Mvc.csproj
+++ b/Framework/Cqrs.Web.Mvc/Cqrs.Web.Mvc.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Web.Mvc.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Web.Mvc.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Framework/Cqrs.Web.Mvc/NullableGuidBinder.cs
+++ b/Framework/Cqrs.Web.Mvc/NullableGuidBinder.cs
@@ -12,8 +12,19 @@ using System.Web.Mvc;
 
 namespace Cqrs.Web.Mvc
 {
+	/// <summary>
+	/// A <see cref="IModelBinder"/> designed to return <see cref="Guid.Empty"/> is not <see cref="Guid"/> is provided.
+	/// </summary>
 	public class NullableGuidBinder : DefaultModelBinder
 	{
+		/// <summary>
+		/// Returns the value of a property using the specified <paramref name="controllerContext"/>, <paramref name="bindingContext"/>, <paramref name="propertyDescriptor"/>, and <paramref name="propertyBinder"/>.
+		/// </summary>
+		/// <param name="controllerContext">The context within which the controller operates. The context information includes the controller, HTTP content, request context, and route data.</param>
+		/// <param name="bindingContext">The context within which the model is bound. The context includes information such as the model object, model name, model type, property filter, and value provider.</param>
+		/// <param name="propertyDescriptor">The descriptor for the property to access. The descriptor provides information such as the component type, property type, and property value. It also provides methods to get or set the property value.</param>
+		/// <param name="propertyBinder">An object that provides a way to bind the property.</param>
+		/// <returns>An object that represents the property value.</returns>
 		protected override object GetPropertyValue(ControllerContext controllerContext, ModelBindingContext bindingContext, PropertyDescriptor propertyDescriptor, IModelBinder propertyBinder)
 		{
 			if (propertyDescriptor.PropertyType == typeof(Guid))

--- a/Framework/Cqrs.WebApi/Cqrs.WebApi.csproj
+++ b/Framework/Cqrs.WebApi/Cqrs.WebApi.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.WebApi.xml</DocumentationFile>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.WebApi.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="cdmdotnet.Logging, Version=1.2.91.71, Culture=neutral, processorArchitecture=MSIL">

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.BlobStorage/Configuration/BlobStoragEventStoreModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.BlobStorage/Configuration/BlobStoragEventStoreModule.cs
@@ -6,6 +6,7 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using System;
 using Cqrs.Azure.BlobStorage;
 using Cqrs.Azure.BlobStorage.Events;
 using Cqrs.Events;
@@ -13,6 +14,10 @@ using Ninject.Modules;
 
 namespace Cqrs.Ninject.Azure.BlobStorage.Configuration
 {
+	/// <summary>
+	/// A <see cref="INinjectModule"/> that wires up the prerequisites of <see cref="IEventStore{TAuthenticationToken}"/> with blob storage.
+	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	public class BlobStoragEventStoreModule<TAuthenticationToken> : NinjectModule
 	{
 		#region Overrides of NinjectModule

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.BlobStorage/Configuration/BlobStorageDataStoreModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.BlobStorage/Configuration/BlobStorageDataStoreModule.cs
@@ -11,6 +11,9 @@ using Ninject.Modules;
 
 namespace Cqrs.Ninject.Azure.BlobStorage.Configuration
 {
+	/// <summary>
+	/// A <see cref="INinjectModule"/> that wires up <see cref="BlobStorageDataStoreConnectionStringFactory"/> as the <see cref="IBlobStorageDataStoreConnectionStringFactory"/>.
+	/// </summary>
 	public class BlobStorageDataStoreModule : NinjectModule
 	{
 		#region Overrides of NinjectModule

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.BlobStorage/Configuration/TableStoragEventStoreModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.BlobStorage/Configuration/TableStoragEventStoreModule.cs
@@ -6,6 +6,7 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using System;
 using Cqrs.Azure.BlobStorage;
 using Cqrs.Azure.BlobStorage.Events;
 using Cqrs.Events;
@@ -13,6 +14,10 @@ using Ninject.Modules;
 
 namespace Cqrs.Ninject.Azure.BlobStorage.Configuration
 {
+	/// <summary>
+	/// A <see cref="INinjectModule"/> that wires up the prerequisites of <see cref="IEventStore{TAuthenticationToken}"/> with table storage.
+	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	public class TableStoragEventStoreModule<TAuthenticationToken> : NinjectModule
 	{
 		#region Overrides of NinjectModule

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.BlobStorage/Configuration/TableStorageDataStoreModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.BlobStorage/Configuration/TableStorageDataStoreModule.cs
@@ -11,6 +11,9 @@ using Ninject.Modules;
 
 namespace Cqrs.Ninject.Azure.BlobStorage.Configuration
 {
+	/// <summary>
+	/// A <see cref="INinjectModule"/> that wires up <see cref="TableStorageDataStoreConnectionStringFactory"/> as the <see cref="ITableStorageDataStoreConnectionStringFactory"/>.
+	/// </summary>
 	public class TableStorageDataStoreModule : NinjectModule
 	{
 		#region Overrides of NinjectModule

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.BlobStorage/Cqrs.Ninject.Azure.BlobStorage.csproj
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.BlobStorage/Cqrs.Ninject.Azure.BlobStorage.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.Azure.BlobStorage.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.Azure.BlobStorage.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.DocumentDb/Configuration/AzureDocumentDbEventStoreModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.DocumentDb/Configuration/AzureDocumentDbEventStoreModule.cs
@@ -6,6 +6,7 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using System;
 using System.Linq;
 using Cqrs.Azure.DocumentDb;
 using Cqrs.Azure.DocumentDb.Events;
@@ -15,8 +16,9 @@ using Ninject.Modules;
 namespace Cqrs.Ninject.Azure.DocumentDb.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureDocumentDbEventStore{TAuthenticationToken}"/> as the <see cref="IEventStore{TAuthenticationToken}"/>.
 	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	public class AzureDocumentDbEventStoreModule<TAuthenticationToken> : NinjectModule
 	{
 		#region Overrides of NinjectModule
@@ -40,10 +42,10 @@ namespace Cqrs.Ninject.Azure.DocumentDb.Configuration
 		public virtual void RegisterFactories()
 		{
 			Bind<IEventBuilder<TAuthenticationToken>>()
-				.To<AzureDocumentDbEventBuilder<TAuthenticationToken>>()
+				.To<DefaultEventBuilder<TAuthenticationToken>>()
 				.InSingletonScope();
 			Bind<IEventDeserialiser<TAuthenticationToken>>()
-				.To<AzureDocumentDbEventDeserialiser<TAuthenticationToken>>()
+				.To<EventDeserialiser<TAuthenticationToken>>()
 				.InSingletonScope();
 		}
 
@@ -54,6 +56,9 @@ namespace Cqrs.Ninject.Azure.DocumentDb.Configuration
 		{
 		}
 
+		/// <summary>
+		/// Register <see cref="IAzureDocumentDbHelper"/> if it hasn't already been registered.
+		/// </summary>
 		public virtual void RegisterAzureHelpers()
 		{
 			if (!Kernel.GetBindings(typeof(IAzureDocumentDbHelper)).Any())

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.DocumentDb/Configuration/AzureDocumentDbModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.DocumentDb/Configuration/AzureDocumentDbModule.cs
@@ -14,7 +14,7 @@ using Ninject.Modules;
 namespace Cqrs.Ninject.Azure.DocumentDb.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureDocumentDbDataStoreConnectionStringFactory"/> as the <see cref="IAzureDocumentDbDataStoreConnectionStringFactory"/>.
 	/// </summary>
 	public class AzureDocumentDbModule : NinjectModule
 	{
@@ -57,6 +57,9 @@ namespace Cqrs.Ninject.Azure.DocumentDb.Configuration
 		{
 		}
 
+		/// <summary>
+		/// Register <see cref="IAzureDocumentDbHelper"/> if it hasn't already been registered.
+		/// </summary>
 		public virtual void RegisterAzureHelpers()
 		{
 			if (!Kernel.GetBindings(typeof(IAzureDocumentDbHelper)).Any())

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.DocumentDb/Configuration/TestAzureDocumentDbEventStoreModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.DocumentDb/Configuration/TestAzureDocumentDbEventStoreModule.cs
@@ -6,8 +6,7 @@
 // // -----------------------------------------------------------------------
 #endregion
 
-using System.Linq;
-using Cqrs.Azure.DocumentDb;
+using System;
 using Cqrs.Azure.DocumentDb.Events;
 using Cqrs.Events;
 using Cqrs.Ninject.Azure.DocumentDb.Events;
@@ -16,59 +15,16 @@ using Ninject.Modules;
 namespace Cqrs.Ninject.Azure.DocumentDb.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureDocumentDbEventStoreConnectionStringFactory"/> as the
+	/// <see cref="IAzureDocumentDbEventStoreConnectionStringFactory"/>.
 	/// </summary>
-	public class TestAzureDocumentDbEventStoreModule<TAuthenticationToken> : NinjectModule
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
+	public class TestAzureDocumentDbEventStoreModule<TAuthenticationToken> : AzureDocumentDbEventStoreModule<TAuthenticationToken>
 	{
-		#region Overrides of NinjectModule
-
-		/// <summary>
-		/// Loads the module into the kernel.
-		/// </summary>
-		public override void Load()
-		{
-			RegisterFactories();
-			RegisterServices();
-			RegisterEventStore();
-			RegisterAzureHelpers();
-		}
-
-		#endregion
-
-		/// <summary>
-		/// Register the all factories
-		/// </summary>
-		public virtual void RegisterFactories()
-		{
-			Bind<IEventBuilder<TAuthenticationToken>>()
-				.To<AzureDocumentDbEventBuilder<TAuthenticationToken>>()
-				.InSingletonScope();
-			Bind<IEventDeserialiser<TAuthenticationToken>>()
-				.To<AzureDocumentDbEventDeserialiser<TAuthenticationToken>>()
-				.InSingletonScope();
-		}
-
-		/// <summary>
-		/// Register the all services
-		/// </summary>
-		public virtual void RegisterServices()
-		{
-		}
-
-		public virtual void RegisterAzureHelpers()
-		{
-			if (!Kernel.GetBindings(typeof(IAzureDocumentDbHelper)).Any())
-			{
-				Bind<IAzureDocumentDbHelper>()
-					.To<AzureDocumentDbHelper>()
-					.InSingletonScope();
-			}
-		}
-
 		/// <summary>
 		/// Register the <see cref="IAzureDocumentDbEventStoreConnectionStringFactory"/> and <see cref="IEventStore{TAuthenticationToken}"/>
 		/// </summary>
-		public virtual void RegisterEventStore()
+		public override void RegisterEventStore()
 		{
 			Bind<IAzureDocumentDbEventStoreConnectionStringFactory>()
 				.To<TestAzureDocumentDbEventStoreConnectionStringFactory>()

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.DocumentDb/Configuration/TestAzureDocumentDbModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.DocumentDb/Configuration/TestAzureDocumentDbModule.cs
@@ -6,8 +6,6 @@
 // // -----------------------------------------------------------------------
 #endregion
 
-using System.Linq;
-using Cqrs.Azure.DocumentDb;
 using Cqrs.Azure.DocumentDb.Factories;
 using Cqrs.Ninject.Azure.DocumentDb.Factories;
 using Ninject.Modules;
@@ -15,57 +13,19 @@ using Ninject.Modules;
 namespace Cqrs.Ninject.Azure.DocumentDb.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="TestAzureDocumentDbDataStoreConnectionStringFactory"/> as the
+	/// <see cref="IAzureDocumentDbDataStoreConnectionStringFactory"/>.
 	/// </summary>
-	public class TestAzureDocumentDbModule : NinjectModule
+	public class TestAzureDocumentDbModule : AzureDocumentDbModule
 	{
-		#region Overrides of NinjectModule
-
-		/// <summary>
-		/// Loads the module into the kernel.
-		/// </summary>
-		public override void Load()
-		{
-			RegisterFactories();
-			RegisterServices();
-			RegisterCqrsRequirements();
-			RegisterAzureHelpers();
-		}
-
-		#endregion
-
 		/// <summary>
 		/// Register the all factories
 		/// </summary>
-		public virtual void RegisterFactories()
+		public override void RegisterFactories()
 		{
 			Bind<IAzureDocumentDbDataStoreConnectionStringFactory>()
 				.To<TestAzureDocumentDbDataStoreConnectionStringFactory>()
 				.InSingletonScope();
-		}
-
-		/// <summary>
-		/// Register the all services
-		/// </summary>
-		public virtual void RegisterServices()
-		{
-		}
-
-		/// <summary>
-		/// Register any CQRS requirements.
-		/// </summary>
-		public virtual void RegisterCqrsRequirements()
-		{
-		}
-
-		public virtual void RegisterAzureHelpers()
-		{
-			if (!Kernel.GetBindings(typeof(IAzureDocumentDbHelper)).Any())
-			{
-				Bind<IAzureDocumentDbHelper>()
-					.To<AzureDocumentDbHelper>()
-					.InSingletonScope();
-			}
 		}
 	}
 }

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.DocumentDb/Cqrs.Ninject.Azure.DocumentDb.csproj
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.DocumentDb/Cqrs.Ninject.Azure.DocumentDb.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.Azure.DocumentDb.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.Azure.DocumentDb.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="cdmdotnet.Logging, Version=1.2.91.71, Culture=neutral, processorArchitecture=MSIL">

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.DocumentDb/Factories/TestAzureDocumentDbDataStoreConnectionStringFactory.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.DocumentDb/Factories/TestAzureDocumentDbDataStoreConnectionStringFactory.cs
@@ -6,29 +6,49 @@
 // // -----------------------------------------------------------------------
 #endregion
 
-using System.Runtime.Remoting.Messaging;
 using Cqrs.Azure.DocumentDb.Factories;
 using cdmdotnet.Logging;
+using cdmdotnet.StateManagement;
+using cdmdotnet.StateManagement.Threaded;
 using Cqrs.Configuration;
+using Cqrs.DataStores;
+using Cqrs.Entities;
 
 namespace Cqrs.Ninject.Azure.DocumentDb.Factories
 {
+	/// <summary>
+	/// A <see cref="AzureDocumentDbDataStoreConnectionStringFactory"/>
+	/// that enables you to set a database name with <see cref="DatabaseName"/>. This means you can randomly generate your own database name per test.
+	/// </summary>
 	public class TestAzureDocumentDbDataStoreConnectionStringFactory : AzureDocumentDbDataStoreConnectionStringFactory
 	{
 		private const string CallContextDatabaseNameKey = "AzureDocumentDbDataStoreConnectionStringFactory¿DatabaseName";
 
+		private static IContextItemCollection Query { get; set; }
+
+		static TestAzureDocumentDbDataStoreConnectionStringFactory()
+		{
+			Query = new ThreadedContextItemCollection();
+		}
+
+		/// <summary>
+		/// The name of the database currently being used.
+		/// </summary>
 		public static string DatabaseName
 		{
 			get
 			{
-				return (string)CallContext.GetData(CallContextDatabaseNameKey);
+				return Query.GetData<string>(CallContextDatabaseNameKey);
 			}
 			set
 			{
-				CallContext.SetData(CallContextDatabaseNameKey, value);
+				Query.SetData(CallContextDatabaseNameKey, value);
 			}
 		}
 
+		/// <summary>
+		/// Instantiates a new instance of <see cref="TestAzureDocumentDbDataStoreConnectionStringFactory"/> defaulting to using <see cref="ConfigurationManager"/>
+		/// </summary>
 		public TestAzureDocumentDbDataStoreConnectionStringFactory(ILogger logger)
 			: base(logger, new ConfigurationManager())
 		{
@@ -36,19 +56,27 @@ namespace Cqrs.Ninject.Azure.DocumentDb.Factories
 
 		#region Implementation of IAzureDocumentDbDataStoreConnectionStringFactory
 
+		/// <summary>
+		/// Gets the value of <see cref="DatabaseName"/>.
+		/// </summary>
 		public override string GetAzureDocumentDbDatabaseName()
 		{
 			return DatabaseName;
 		}
 
+		#endregion
+
 		#region Overrides of AzureDocumentDbDataStoreConnectionStringFactory
 
-		public override bool UseOneCollectionPerDataStore()
+		/// <summary>
+		/// Indicates if a different collection should be used per <see cref="IEntity"/>/<see cref="IDataStore{TData}"/> or a single collection used for all instances of <see cref="IDataStore{TData}"/> and <see cref="IDataStore{TData}"/>.
+		/// Setting this to true can become expensive as each <see cref="IEntity"/> will have it's own collection. Check the relevant SDK/pricing models.
+		/// </summary>
+		/// <returns>Always returns true.</returns>
+		public override bool UseSingleCollectionForAllDataStores()
 		{
 			return true;
 		}
-
-		#endregion
 
 		#endregion
 	}

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.CommandBus/Configuration/AzureCommandBusReceiverModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.CommandBus/Configuration/AzureCommandBusReceiverModule.cs
@@ -1,58 +1,24 @@
-﻿using System.Linq;
+﻿#region Copyright
+// // -----------------------------------------------------------------------
+// // <copyright company="Chinchilla Software Limited">
+// // 	Copyright Chinchilla Software Limited. All rights reserved.
+// // </copyright>
+// // -----------------------------------------------------------------------
+#endregion
+
+using System;
 using Cqrs.Azure.ServiceBus;
-using Cqrs.Bus;
+using Cqrs.Commands;
 using Ninject.Modules;
 
 namespace Cqrs.Azure.EventHub.CommandBus.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureCommandBusReceiver{TAuthenticationToken}"/> as the <see cref="ICommandReceiver"/> and other require components.
 	/// </summary>
-	public class AzureCommandBusReceiverModule<TAuthenticationToken> : NinjectModule
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
+	[Obsolete("Use AzureCommandHubReceiverModule")]
+	public class AzureCommandBusReceiverModule<TAuthenticationToken> : AzureCommandHubReceiverModule<TAuthenticationToken>
 	{
-		#region Overrides of NinjectModule
-
-		/// <summary>
-		/// Loads the module into the kernel.
-		/// </summary>
-		public override void Load()
-		{
-			bool isMessageSerialiserBound = Kernel.GetBindings(typeof(IAzureBusHelper<TAuthenticationToken>)).Any();
-			if (!isMessageSerialiserBound)
-			{
-				Bind<IAzureBusHelper<TAuthenticationToken>>()
-					.To<AzureBusHelper<TAuthenticationToken>>()
-					.InSingletonScope();
-			}
-
-			RegisterCommandHandlerRegistrar();
-			RegisterCommandMessageSerialiser();
-		}
-
-		#endregion
-
-		/// <summary>
-		/// Register the Cqrs command handler registrar
-		/// </summary>
-		public virtual void RegisterCommandHandlerRegistrar()
-		{
-			Bind<ICommandHandlerRegistrar>()
-				.To<AzureCommandBusReceiver<TAuthenticationToken>>()
-				.InSingletonScope();
-		}
-
-		/// <summary>
-		/// Register the Cqrs command handler message serialiser
-		/// </summary>
-		public virtual void RegisterCommandMessageSerialiser()
-		{
-			bool isMessageSerialiserBound = Kernel.GetBindings(typeof(IMessageSerialiser<TAuthenticationToken>)).Any();
-			if (!isMessageSerialiserBound)
-			{
-				Bind<IMessageSerialiser<TAuthenticationToken>>()
-					.To<MessageSerialiser<TAuthenticationToken>>()
-					.InSingletonScope();
-			}
-		}
 	}
 }

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.CommandBus/Configuration/AzureCommandBusSenderModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.CommandBus/Configuration/AzureCommandBusSenderModule.cs
@@ -1,4 +1,12 @@
-﻿using System.Linq;
+﻿#region Copyright
+// // -----------------------------------------------------------------------
+// // <copyright company="Chinchilla Software Limited">
+// // 	Copyright Chinchilla Software Limited. All rights reserved.
+// // </copyright>
+// // -----------------------------------------------------------------------
+#endregion
+
+using System;
 using Cqrs.Azure.ServiceBus;
 using Cqrs.Commands;
 using Ninject.Modules;
@@ -6,61 +14,11 @@ using Ninject.Modules;
 namespace Cqrs.Azure.EventHub.CommandBus.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureCommandBusPublisher{TAuthenticationToken}"/> as the <see cref="ICommandPublisher{TAuthenticationToken}"/> and other require components.
 	/// </summary>
-	public class AzureCommandBusSenderModule<TAuthenticationToken> : NinjectModule
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
+	[Obsolete("Use AzureCommandHubPublisherModule")]
+	public class AzureCommandBusSenderModule<TAuthenticationToken> : AzureCommandHubPublisherModule<TAuthenticationToken>
 	{
-		#region Overrides of NinjectModule
-
-		/// <summary>
-		/// Loads the module into the kernel.
-		/// </summary>
-		public override void Load()
-		{
-			bool isMessageSerialiserBound = Kernel.GetBindings(typeof(IAzureBusHelper<TAuthenticationToken>)).Any();
-			if (!isMessageSerialiserBound)
-			{
-				Bind<IAzureBusHelper<TAuthenticationToken>>()
-					.To<AzureBusHelper<TAuthenticationToken>>()
-					.InSingletonScope();
-			}
-
-			RegisterCommandSender();
-			RegisterCommandMessageSerialiser();
-		}
-
-		#endregion
-
-		/// <summary>
-		/// Register the Cqrs command sender
-		/// </summary>
-		public virtual void RegisterCommandSender()
-		{
-			Bind<ICommandSender<TAuthenticationToken>>()
-				.To<AzureCommandBusPublisher<TAuthenticationToken>>()
-				.InSingletonScope();
-
-			Bind<ICommandPublisher<TAuthenticationToken>>()
-				.To<AzureCommandBusPublisher<TAuthenticationToken>>()
-				.InSingletonScope();
-
-			Bind<ISendAndWaitCommandSender<TAuthenticationToken>>()
-				.To<AzureCommandBusPublisher<TAuthenticationToken>>()
-				.InSingletonScope();
-		}
-
-		/// <summary>
-		/// Register the Cqrs command handler message serialiser
-		/// </summary>
-		public virtual void RegisterCommandMessageSerialiser()
-		{
-			bool isMessageSerialiserBound = Kernel.GetBindings(typeof(IMessageSerialiser<TAuthenticationToken>)).Any();
-			if (!isMessageSerialiserBound)
-			{
-				Bind<IMessageSerialiser<TAuthenticationToken>>()
-					.To<MessageSerialiser<TAuthenticationToken>>()
-					.InSingletonScope();
-			}
-		}
 	}
 }

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.CommandBus/Configuration/AzureQueuedCommandBusReceiverModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.CommandBus/Configuration/AzureQueuedCommandBusReceiverModule.cs
@@ -1,15 +1,24 @@
-﻿using Cqrs.Azure.ServiceBus;
-using Cqrs.Bus;
+﻿#region Copyright
+// // -----------------------------------------------------------------------
+// // <copyright company="Chinchilla Software Limited">
+// // 	Copyright Chinchilla Software Limited. All rights reserved.
+// // </copyright>
+// // -----------------------------------------------------------------------
+#endregion
+
+using System;
+using Cqrs.Azure.ServiceBus;
+using Cqrs.Commands;
+using Ninject.Modules;
 
 namespace Cqrs.Azure.EventHub.CommandBus.Configuration
 {
-	public class AzureQueuedCommandBusReceiverModule<TAuthenticationToken> : AzureCommandBusReceiverModule<TAuthenticationToken>
+	/// <summary>
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureQueuedCommandBusReceiver{TAuthenticationToken}"/> as the <see cref="ICommandReceiver"/> and other require components.
+	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
+	[Obsolete("Use AzureQueuedCommandHubReceiverModule")]
+	public class AzureQueuedCommandBusReceiverModule<TAuthenticationToken> : AzureQueuedCommandHubReceiverModule<TAuthenticationToken>
 	{
-		public override void RegisterCommandHandlerRegistrar()
-		{
-			Bind<ICommandHandlerRegistrar>()
-				.To<AzureQueuedCommandBusReceiver<TAuthenticationToken>>()
-				.InSingletonScope();
-		}
 	}
 }

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.CommandBus/Cqrs.Ninject.Azure.EventHub.CommandBus.csproj
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.CommandBus/Cqrs.Ninject.Azure.EventHub.CommandBus.csproj
@@ -26,6 +26,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <DocumentationFile>bin\Debug\Cqrs.Azure.EventHub.CommandBus.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,6 +37,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <DocumentationFile>bin\Release\Cqrs.Azure.EventHub.CommandBus.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ninject">
@@ -50,8 +52,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configuration\AzureCommandHubPublisherModule.cs" />
+    <Compile Include="Configuration\AzureCommandBusPublisherModule.cs" />
+    <Compile Include="Configuration\AzureCommandHubReceiverModule.cs" />
     <Compile Include="Configuration\AzureCommandBusSenderModule.cs" />
     <Compile Include="Configuration\AzureCommandBusReceiverModule.cs" />
+    <Compile Include="Configuration\AzureQueuedCommandHubReceiverModule.cs" />
     <Compile Include="Configuration\AzureQueuedCommandBusReceiverModule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.CommandBus/Cqrs.Ninject.Azure.EventHub.CommandBus.nuspec
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.CommandBus/Cqrs.Ninject.Azure.EventHub.CommandBus.nuspec
@@ -13,6 +13,10 @@
 		<copyright>Copyright 2015</copyright>
 		<tags>CQRS CQRS.NET Pub/Sub Azure EventHubs Ninject</tags>
 		<releaseNotes>
+			Version 2.2
+
+			* Deprecated all CommandBus named classes for CommandHub.
+
 			Version 2.0
 
 			* New

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.EventBus/Configuration/AzureEventBusReceiverModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.EventBus/Configuration/AzureEventBusReceiverModule.cs
@@ -1,58 +1,24 @@
-﻿using System.Linq;
+﻿#region Copyright
+// // -----------------------------------------------------------------------
+// // <copyright company="Chinchilla Software Limited">
+// // 	Copyright Chinchilla Software Limited. All rights reserved.
+// // </copyright>
+// // -----------------------------------------------------------------------
+#endregion
+
+using System;
 using Cqrs.Azure.ServiceBus;
-using Cqrs.Bus;
+using Cqrs.Events;
 using Ninject.Modules;
 
 namespace Cqrs.Azure.EventHub.EventBus.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureEventBusReceiver{TAuthenticationToken}"/> as the <see cref="IEventReceiver"/> and other require components.
 	/// </summary>
-	public class AzureEventBusReceiverModule<TAuthenticationToken> : NinjectModule
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
+	[Obsolete("Use AzureEventHubReceiverModule")]
+	public class AzureEventBusReceiverModule<TAuthenticationToken> : AzureEventHubReceiverModule<TAuthenticationToken>
 	{
-		#region Overrides of NinjectModule
-
-		/// <summary>
-		/// Loads the module into the kernel.
-		/// </summary>
-		public override void Load()
-		{
-			bool isMessageSerialiserBound = Kernel.GetBindings(typeof(IAzureBusHelper<TAuthenticationToken>)).Any();
-			if (!isMessageSerialiserBound)
-			{
-				Bind<IAzureBusHelper<TAuthenticationToken>>()
-					.To<AzureBusHelper<TAuthenticationToken>>()
-					.InSingletonScope();
-			}
-
-			RegisterEventHandlerRegistrar();
-			RegisterEventMessageSerialiser();
-		}
-
-		#endregion
-
-		/// <summary>
-		/// Register the Cqrs event handler registrar
-		/// </summary>
-		public virtual void RegisterEventHandlerRegistrar()
-		{
-			Bind<IEventHandlerRegistrar>()
-				.To<AzureEventBusReceiver<TAuthenticationToken>>()
-				.InSingletonScope();
-		}
-
-		/// <summary>
-		/// Register the Cqrs event handler message serialiser
-		/// </summary>
-		public virtual void RegisterEventMessageSerialiser()
-		{
-			bool isMessageSerialiserBound = Kernel.GetBindings(typeof(IMessageSerialiser<TAuthenticationToken>)).Any();
-			if (!isMessageSerialiserBound)
-			{
-				Bind<IMessageSerialiser<TAuthenticationToken>>()
-					.To<MessageSerialiser<TAuthenticationToken>>()
-					.InSingletonScope();
-			}
-		}
 	}
 }

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.EventBus/Configuration/AzureEventPublisherModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.EventBus/Configuration/AzureEventPublisherModule.cs
@@ -1,4 +1,12 @@
-﻿using System.Linq;
+﻿#region Copyright
+// // -----------------------------------------------------------------------
+// // <copyright company="Chinchilla Software Limited">
+// // 	Copyright Chinchilla Software Limited. All rights reserved.
+// // </copyright>
+// // -----------------------------------------------------------------------
+#endregion
+
+using System;
 using Cqrs.Azure.ServiceBus;
 using Cqrs.Events;
 using Ninject.Modules;
@@ -6,53 +14,11 @@ using Ninject.Modules;
 namespace Cqrs.Azure.EventHub.EventBus.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureEventBusPublisher{TAuthenticationToken}"/> as the <see cref="IEventPublisher{TAuthenticationToken}"/> and other require components.
 	/// </summary>
-	public class AzureEventPublisherModule<TAuthenticationToken> : NinjectModule
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
+	[Obsolete("Use AzureEventHubPublisherModule")]
+	public class AzureEventPublisherModule<TAuthenticationToken> : AzureEventHubPublisherModule<TAuthenticationToken> 
 	{
-		#region Overrides of NinjectModule
-
-		/// <summary>
-		/// Loads the module into the kernel.
-		/// </summary>
-		public override void Load()
-		{
-			bool isMessageSerialiserBound = Kernel.GetBindings(typeof(IAzureBusHelper<TAuthenticationToken>)).Any();
-			if (!isMessageSerialiserBound)
-			{
-				Bind<IAzureBusHelper<TAuthenticationToken>>()
-					.To<AzureBusHelper<TAuthenticationToken>>()
-					.InSingletonScope();
-			}
-
-			RegisterEventPublisher();
-			RegisterEventMessageSerialiser();
-		}
-
-		#endregion
-
-		/// <summary>
-		/// Register the Cqrs event publisher
-		/// </summary>
-		public virtual void RegisterEventPublisher()
-		{
-			Bind<IEventPublisher<TAuthenticationToken>>()
-				.To<AzureEventBusPublisher<TAuthenticationToken>>()
-				.InSingletonScope();
-		}
-
-		/// <summary>
-		/// Register the Cqrs event handler message serialiser
-		/// </summary>
-		public virtual void RegisterEventMessageSerialiser()
-		{
-			bool isMessageSerialiserBound = Kernel.GetBindings(typeof(IMessageSerialiser<TAuthenticationToken>)).Any();
-			if (!isMessageSerialiserBound)
-			{
-				Bind<IMessageSerialiser<TAuthenticationToken>>()
-					.To<MessageSerialiser<TAuthenticationToken>>()
-					.InSingletonScope();
-			}
-		}
 	}
 }

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.EventBus/Configuration/AzureQueuedEventBusReceiverModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.EventBus/Configuration/AzureQueuedEventBusReceiverModule.cs
@@ -1,15 +1,24 @@
-﻿using Cqrs.Azure.ServiceBus;
-using Cqrs.Bus;
+﻿#region Copyright
+// // -----------------------------------------------------------------------
+// // <copyright company="Chinchilla Software Limited">
+// // 	Copyright Chinchilla Software Limited. All rights reserved.
+// // </copyright>
+// // -----------------------------------------------------------------------
+#endregion
+
+using System;
+using Cqrs.Azure.ServiceBus;
+using Cqrs.Events;
+using Ninject.Modules;
 
 namespace Cqrs.Azure.EventHub.EventBus.Configuration
 {
-	public class AzureQueuedEventBusReceiverModule<TAuthenticationToken> : AzureEventBusReceiverModule<TAuthenticationToken>
+	/// <summary>
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureQueuedEventBusReceiver{TAuthenticationToken}"/> as the <see cref="IEventReceiver"/> and other require components.
+	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
+	[Obsolete("Use AzureQueuedEventHubReceiverModule")]
+	public class AzureQueuedEventBusReceiverModule<TAuthenticationToken> : AzureQueuedEventHubReceiverModule<TAuthenticationToken>
 	{
-		public override void RegisterEventHandlerRegistrar()
-		{
-			Bind<IEventHandlerRegistrar>()
-				.To<AzureQueuedEventBusReceiver<TAuthenticationToken>>()
-				.InSingletonScope();
-		}
 	}
 }

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.EventBus/Cqrs.Ninject.Azure.EventHub.EventBus.csproj
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.EventBus/Cqrs.Ninject.Azure.EventHub.EventBus.csproj
@@ -26,6 +26,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <DocumentationFile>bin\Debug\Cqrs.Azure.EventHub.EventBus.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,6 +37,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <DocumentationFile>bin\Release\Cqrs.Azure.EventHub.EventBus.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ninject">
@@ -50,8 +52,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configuration\AzureEventHubPublisherModule.cs" />
+    <Compile Include="Configuration\AzureEventHubReceiverModule.cs" />
     <Compile Include="Configuration\AzureEventBusReceiverModule.cs" />
+    <Compile Include="Configuration\AzureEventBusPublisherModule.cs" />
     <Compile Include="Configuration\AzureEventPublisherModule.cs" />
+    <Compile Include="Configuration\AzureQueuedEventHubReceiverModule.cs" />
     <Compile Include="Configuration\AzureQueuedEventBusReceiverModule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.EventBus/Cqrs.Ninject.Azure.EventHub.EventBus.nuspec
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.EventHub.EventBus/Cqrs.Ninject.Azure.EventHub.EventBus.nuspec
@@ -13,6 +13,11 @@
 		<copyright>Copyright 2015</copyright>
 		<tags>CQRS CQRS.NET Pub/Sub Azure EventHubs Ninject</tags>
 		<releaseNotes>
+			Version 2.2
+
+			* Deprecated all EventBus named classes for EventHub.
+
+			* New
 			Version 2.0
 
 			* New

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.CommandBus/Configuration/AzureCommandBusPublisherModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.CommandBus/Configuration/AzureCommandBusPublisherModule.cs
@@ -6,6 +6,7 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using System;
 using System.Linq;
 using Cqrs.Azure.ServiceBus;
 using Cqrs.Commands;
@@ -14,8 +15,9 @@ using Ninject.Modules;
 namespace Cqrs.Ninject.Azure.ServiceBus.CommandBus.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureCommandBusPublisher{TAuthenticationToken}"/> as the <see cref="ICommandPublisher{TAuthenticationToken}"/> and other require components.
 	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	public class AzureCommandBusPublisherModule<TAuthenticationToken> : NinjectModule
 	{
 		#region Overrides of NinjectModule
@@ -40,12 +42,14 @@ namespace Cqrs.Ninject.Azure.ServiceBus.CommandBus.Configuration
 		#endregion
 
 		/// <summary>
-		/// Register the Cqrs command sender
+		/// Register the CQRS command publisher
 		/// </summary>
 		public virtual void RegisterCommandSender()
 		{
+#pragma warning disable 618
 			Bind<ICommandSender<TAuthenticationToken>>()
-				.To<AzureCommandBusPublisher<TAuthenticationToken>>()
+#pragma warning restore 618
+.To<AzureCommandBusPublisher<TAuthenticationToken>>()
 				.InSingletonScope();
 
 			Bind<ICommandPublisher<TAuthenticationToken>>()
@@ -58,7 +62,7 @@ namespace Cqrs.Ninject.Azure.ServiceBus.CommandBus.Configuration
 		}
 
 		/// <summary>
-		/// Register the Cqrs command handler message serialiser
+		/// Register the CQRS command handler message serialiser
 		/// </summary>
 		public virtual void RegisterCommandMessageSerialiser()
 		{

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.CommandBus/Configuration/AzureCommandBusReceiverModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.CommandBus/Configuration/AzureCommandBusReceiverModule.cs
@@ -6,6 +6,7 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using System;
 using System.Linq;
 using Cqrs.Azure.ServiceBus;
 using Cqrs.Bus;
@@ -16,8 +17,9 @@ using Ninject.Modules;
 namespace Cqrs.Ninject.Azure.ServiceBus.CommandBus.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureCommandBusReceiver{TAuthenticationToken}"/> as the <see cref="ICommandReceiver"/> and other require components.
 	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	public class AzureCommandBusReceiverModule<TAuthenticationToken> : NinjectModule
 	{
 		#region Overrides of NinjectModule
@@ -44,6 +46,11 @@ namespace Cqrs.Ninject.Azure.ServiceBus.CommandBus.Configuration
 
 		#endregion
 
+		/// <summary>
+		/// Checks if an existing <typeparamref name="TBus"/> has already been registered, if not
+		/// it tries to instantiates a new instance via resolution and registers that instance.
+		/// </summary>
+		/// <typeparam name="TBus">The <see cref="Type"/> of bus to resolve. Best if a class not an interface.</typeparam>
 		public virtual TBus GetOrCreateBus<TBus>()
 			where TBus : ICommandReceiver<TAuthenticationToken>, ICommandHandlerRegistrar
 		{
@@ -63,7 +70,7 @@ namespace Cqrs.Ninject.Azure.ServiceBus.CommandBus.Configuration
 		}
 
 		/// <summary>
-		/// Register the Cqrs command receiver
+		/// Register the CQRS command receiver
 		/// </summary>
 		public virtual void RegisterCommandReceiver<TBus>(TBus bus)
 			where TBus : ICommandReceiver<TAuthenticationToken>, ICommandHandlerRegistrar
@@ -74,7 +81,7 @@ namespace Cqrs.Ninject.Azure.ServiceBus.CommandBus.Configuration
 		}
 
 		/// <summary>
-		/// Register the Cqrs command handler registrar
+		/// Register the CQRS command handler registrar
 		/// </summary>
 		public virtual void RegisterCommandHandlerRegistrar<TBus>(TBus bus)
 			where TBus : ICommandReceiver<TAuthenticationToken>, ICommandHandlerRegistrar
@@ -85,7 +92,7 @@ namespace Cqrs.Ninject.Azure.ServiceBus.CommandBus.Configuration
 		}
 
 		/// <summary>
-		/// Register the Cqrs command handler message serialiser
+		/// Register the CQRS command handler message serialiser
 		/// </summary>
 		public virtual void RegisterCommandMessageSerialiser()
 		{

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.CommandBus/Configuration/AzureCommandBusSenderModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.CommandBus/Configuration/AzureCommandBusSenderModule.cs
@@ -7,13 +7,16 @@
 #endregion
 
 using System;
+using Cqrs.Azure.ServiceBus;
+using Cqrs.Commands;
 using Ninject.Modules;
 
 namespace Cqrs.Ninject.Azure.ServiceBus.CommandBus.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureCommandBusPublisher{TAuthenticationToken}"/> as the <see cref="ICommandPublisher{TAuthenticationToken}"/> and other require components.
 	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	[Obsolete("Use AzureCommandBusPublisherModule")]
 	public class AzureCommandBusSenderModule<TAuthenticationToken> : AzureCommandBusPublisherModule<TAuthenticationToken>
 	{

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.CommandBus/Configuration/AzureQueuedCommandBusReceiverModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.CommandBus/Configuration/AzureQueuedCommandBusReceiverModule.cs
@@ -6,11 +6,18 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using System;
 using System.Linq;
 using Cqrs.Azure.ServiceBus;
+using Cqrs.Commands;
+using Ninject.Modules;
 
 namespace Cqrs.Ninject.Azure.ServiceBus.CommandBus.Configuration
 {
+	/// <summary>
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureQueuedCommandBusReceiver{TAuthenticationToken}"/> as the <see cref="ICommandReceiver"/> and other require components.
+	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	public class AzureQueuedCommandBusReceiverModule<TAuthenticationToken> : AzureCommandBusReceiverModule<TAuthenticationToken>
 	{
 		/// <summary>

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.CommandBus/Cqrs.Ninject.Azure.ServiceBus.CommandBus.csproj
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.CommandBus/Cqrs.Ninject.Azure.ServiceBus.CommandBus.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.Azure.ServiceBus.CommandBus.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.Azure.ServiceBus.CommandBus.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ninject">

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.EventBus/Configuration/AzureEventBusPublisherModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.EventBus/Configuration/AzureEventBusPublisherModule.cs
@@ -6,6 +6,7 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using System;
 using System.Linq;
 using Cqrs.Azure.ServiceBus;
 using Cqrs.Events;
@@ -14,8 +15,9 @@ using Ninject.Modules;
 namespace Cqrs.Ninject.Azure.ServiceBus.EventBus.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureEventBusPublisher{TAuthenticationToken}"/> as the <see cref="IEventPublisher{TAuthenticationToken}"/> and other require components.
 	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	public class AzureEventBusPublisherModule<TAuthenticationToken> : NinjectModule
 	{
 		#region Overrides of NinjectModule
@@ -40,7 +42,7 @@ namespace Cqrs.Ninject.Azure.ServiceBus.EventBus.Configuration
 		#endregion
 
 		/// <summary>
-		/// Register the Cqrs event publisher
+		/// Register the CQRS event publisher
 		/// </summary>
 		public virtual void RegisterEventPublisher()
 		{
@@ -50,7 +52,7 @@ namespace Cqrs.Ninject.Azure.ServiceBus.EventBus.Configuration
 		}
 
 		/// <summary>
-		/// Register the Cqrs event handler message serialiser
+		/// Register the CQRS event handler message serialiser
 		/// </summary>
 		public virtual void RegisterEventMessageSerialiser()
 		{

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.EventBus/Configuration/AzureEventBusReceiverModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.EventBus/Configuration/AzureEventBusReceiverModule.cs
@@ -6,6 +6,7 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using System;
 using System.Linq;
 using Cqrs.Azure.ServiceBus;
 using Cqrs.Bus;
@@ -16,8 +17,9 @@ using Ninject.Modules;
 namespace Cqrs.Ninject.Azure.ServiceBus.EventBus.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureEventBusReceiver{TAuthenticationToken}"/> as the <see cref="IEventReceiver"/> and other require components.
 	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	public class AzureEventBusReceiverModule<TAuthenticationToken> : NinjectModule
 	{
 		#region Overrides of NinjectModule
@@ -44,6 +46,11 @@ namespace Cqrs.Ninject.Azure.ServiceBus.EventBus.Configuration
 
 		#endregion
 
+		/// <summary>
+		/// Checks if an existing <typeparamref name="TBus"/> has already been registered, if not
+		/// it tries to instantiates a new instance via resolution and registers that instance.
+		/// </summary>
+		/// <typeparam name="TBus">The <see cref="Type"/> of bus to resolve. Best if a class not an interface.</typeparam>
 		public virtual TBus GetOrCreateBus<TBus>()
 			where TBus : IEventReceiver<TAuthenticationToken>, IEventHandlerRegistrar
 		{
@@ -63,7 +70,7 @@ namespace Cqrs.Ninject.Azure.ServiceBus.EventBus.Configuration
 		}
 
 		/// <summary>
-		/// Register the Cqrs event receiver
+		/// Register the CQRS event receiver
 		/// </summary>
 		public virtual void RegisterEventReceiver<TBus>(TBus bus)
 			where TBus : IEventReceiver<TAuthenticationToken>, IEventHandlerRegistrar
@@ -74,7 +81,7 @@ namespace Cqrs.Ninject.Azure.ServiceBus.EventBus.Configuration
 		}
 
 		/// <summary>
-		/// Register the Cqrs event handler registrar
+		/// Register the CQRS event handler registrar
 		/// </summary>
 		public virtual void RegisterEventHandlerRegistrar<TBus>(TBus bus)
 			where TBus : IEventReceiver<TAuthenticationToken>, IEventHandlerRegistrar
@@ -89,7 +96,7 @@ namespace Cqrs.Ninject.Azure.ServiceBus.EventBus.Configuration
 		}
 
 		/// <summary>
-		/// Register the Cqrs event handler message serialiser
+		/// Register the CQRS event handler message serialiser
 		/// </summary>
 		public virtual void RegisterEventMessageSerialiser()
 		{

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.EventBus/Configuration/AzureEventPublisherModule.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.EventBus/Configuration/AzureEventPublisherModule.cs
@@ -7,13 +7,16 @@
 #endregion
 
 using System;
+using Cqrs.Azure.ServiceBus;
+using Cqrs.Events;
 using Ninject.Modules;
 
 namespace Cqrs.Ninject.Azure.ServiceBus.EventBus.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="AzureEventBusPublisher{TAuthenticationToken}"/> as the <see cref="IEventPublisher{TAuthenticationToken}"/> and other require components.
 	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	[Obsolete("Use AzureEventBusPublisherModule")]
 	public class AzureEventPublisherModule<TAuthenticationToken> : AzureEventBusPublisherModule<TAuthenticationToken> 
 	{

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.EventBus/Cqrs.Ninject.Azure.ServiceBus.EventBus.csproj
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.ServiceBus.EventBus/Cqrs.Ninject.Azure.ServiceBus.EventBus.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.Azure.ServiceBus.EventBus.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.Azure.ServiceBus.EventBus.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ninject">
@@ -50,6 +52,7 @@
     <Compile Include="Configuration\AzureEventBusReceiverModule.cs" />
     <Compile Include="Configuration\AzureEventBusPublisherModule.cs" />
     <Compile Include="Configuration\AzureEventPublisherModule.cs" />
+    <Compile Include="Configuration\AzureQueuedEventBusReceiverModule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.Wcf/Configuration/SimplifiedNinjectWcf.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.Wcf/Configuration/SimplifiedNinjectWcf.cs
@@ -19,6 +19,11 @@ using Ninject.Web.Common;
 
 namespace Cqrs.Ninject.Azure.Wcf.Configuration
 {
+	/// <summary>
+	/// A <see cref="WebActivatorEx.PreApplicationStartMethodAttribute"/> that calls <see cref="Start"/>
+	/// and <see cref="WebActivatorEx.ApplicationShutdownMethodAttribute"/> that calls <see cref="Stop"/>
+	/// configuring Simplified SQL by wiring up <see cref="SimplifiedSqlModule{TAuthenticationToken}"/>.
+	/// </summary>
 	public static class SimplifiedNinjectWcf
 	{
 		private static readonly Bootstrapper Bootstrapper = new Bootstrapper();

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.Wcf/Cqrs.Ninject.Azure.Wcf.csproj
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.Wcf/Cqrs.Ninject.Azure.Wcf.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.Azure.Wcf.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.Azure.Wcf.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="cdmdotnet.Logging, Version=1.2.91.71, Culture=neutral, processorArchitecture=MSIL">

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.WebJobs/Cqrs.Ninject.Azure.WebJobs.csproj
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.WebJobs/Cqrs.Ninject.Azure.WebJobs.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.Azure.WebJobs.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.Azure.WebJobs.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="cdmdotnet.Logging, Version=1.2.91.71, Culture=neutral, processorArchitecture=MSIL">

--- a/Framework/Ninject/Azure/Cqrs.Ninject.Azure.WebJobs/CqrsNinjectJobHost.cs
+++ b/Framework/Ninject/Azure/Cqrs.Ninject.Azure.WebJobs/CqrsNinjectJobHost.cs
@@ -21,8 +21,15 @@ namespace Cqrs.Ninject.Azure.WebJobs
 	public class CqrsNinjectJobHost<TAuthenticationToken, TAuthenticationTokenHelper> : CqrsWebHost<TAuthenticationToken, TAuthenticationTokenHelper, WebJobHostModule>
 		where TAuthenticationTokenHelper : class, IAuthenticationTokenHelper<TAuthenticationToken>
 	{
+		/// <summary>
+		/// The <see cref="CoreHost"/> to run, WebJobs are console apps and console apps start via a static method, this is the instance
+		/// that static method will actually run.
+		/// </summary>
 		protected static CoreHost<TAuthenticationToken> CoreHost { get; set; }
 
+		/// <summary>
+		/// An <see cref="Action"/> to run just before <see cref="JobHost.RunAndBlock"/>.
+		/// </summary>
 		protected static Action PreRunAndBlockAction { get; set; }
 
 		/// <remarks>

--- a/Framework/Ninject/Cqrs.Ninject.Akka/Configuration/AkkaModule.cs
+++ b/Framework/Ninject/Cqrs.Ninject.Akka/Configuration/AkkaModule.cs
@@ -14,12 +14,16 @@ using Cqrs.Akka.Domain;
 using Cqrs.Akka.Events;
 using Cqrs.Bus;
 using Cqrs.Configuration;
+using Cqrs.Ninject.Configuration;
 using Ninject.Modules;
-using Ninject.Parameters;
 
 namespace Cqrs.Ninject.Akka.Configuration
 {
-	public class AkkaModule<TAuthenticationToken> : NinjectModule
+	/// <summary>
+	/// A <see cref="INinjectModule"/> that wires up many of the prerequisites for running CQRS.NET with Akka.NET
+	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
+	public class AkkaModule<TAuthenticationToken> : ResolvableModule
 	{
 		#region Overrides of NinjectModule
 
@@ -55,15 +59,5 @@ namespace Cqrs.Ninject.Akka.Configuration
 		}
 
 		#endregion
-
-		protected T Resolve<T>()
-		{
-			return (T)Resolve(typeof(T));
-		}
-
-		protected object Resolve(Type serviceType)
-		{
-			return Kernel.Resolve(Kernel.CreateRequest(serviceType, null, new Parameter[0], true, true)).SingleOrDefault();
-		}
 	}
 }

--- a/Framework/Ninject/Cqrs.Ninject.Akka/Cqrs.Ninject.Akka.csproj
+++ b/Framework/Ninject/Cqrs.Ninject.Akka/Cqrs.Ninject.Akka.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.Akka.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.Akka.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Akka">

--- a/Framework/Ninject/Cqrs.Ninject.EventStore/Configuration/EventStoreModule.cs
+++ b/Framework/Ninject/Cqrs.Ninject.EventStore/Configuration/EventStoreModule.cs
@@ -1,12 +1,14 @@
-﻿using Cqrs.EventStore;
+﻿using System;
+using Cqrs.EventStore;
 using Cqrs.Events;
 using Ninject.Modules;
 
 namespace Cqrs.Ninject.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="EventStore.EventStore{TAuthenticationToken}"/> as the <see cref="IEventStore{TAuthenticationToken}"/>.
 	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	public class EventStoreModule<TAuthenticationToken> : NinjectModule
 	{
 		#region Overrides of NinjectModule

--- a/Framework/Ninject/Cqrs.Ninject.EventStore/Cqrs.Ninject.EventStore.csproj
+++ b/Framework/Ninject/Cqrs.Ninject.EventStore/Cqrs.Ninject.EventStore.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.EventStore.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.EventStore.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EventStore.ClientAPI, Version=3.0.2.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Framework/Ninject/Cqrs.Ninject.InProcess.CommandBus/Cqrs.Ninject.InProcess.CommandBus.csproj
+++ b/Framework/Ninject/Cqrs.Ninject.InProcess.CommandBus/Cqrs.Ninject.InProcess.CommandBus.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.InProcess.CommandBus.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.InProcess.CommandBus.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ninject">

--- a/Framework/Ninject/Cqrs.Ninject.InProcess.EventBus/Cqrs.Ninject.InProcess.EventBus.csproj
+++ b/Framework/Ninject/Cqrs.Ninject.InProcess.EventBus/Cqrs.Ninject.InProcess.EventBus.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.InProcess.EventBus.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.InProcess.EventBus.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ninject">

--- a/Framework/Ninject/Cqrs.Ninject.InProcess.EventStore/Cqrs.Ninject.InProcess.EventStore.csproj
+++ b/Framework/Ninject/Cqrs.Ninject.InProcess.EventStore/Cqrs.Ninject.InProcess.EventStore.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.InProcess.EventStore.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.InProcess.EventStore.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ninject">

--- a/Framework/Ninject/Cqrs.Ninject.Mongo/Configuration/MongoModule.cs
+++ b/Framework/Ninject/Cqrs.Ninject.Mongo/Configuration/MongoModule.cs
@@ -11,6 +11,9 @@ using Ninject.Modules;
 
 namespace Cqrs.Ninject.Mongo.Configuration
 {
+	/// <summary>
+	/// A <see cref="INinjectModule"/> that wires up <see cref="MongoDataStoreConnectionStringFactory"/> as the <see cref="IMongoDataStoreConnectionStringFactory"/>.
+	/// </summary>
 	public class MongoModule : NinjectModule
 	{
 		#region Overrides of NinjectModule

--- a/Framework/Ninject/Cqrs.Ninject.Mongo/Configuration/TestMongoModule.cs
+++ b/Framework/Ninject/Cqrs.Ninject.Mongo/Configuration/TestMongoModule.cs
@@ -7,12 +7,13 @@
 #endregion
 
 using Cqrs.Mongo.Factories;
+using Ninject.Modules;
 
 namespace Cqrs.Ninject.Mongo.Configuration
 {
 	/// <summary>
-	/// A <see cref="MongoModule"/> that assumes the connection string is keyed "MongoDb-Test".
-	/// This will generated a random suffix to the database name so as to create a unique store for testing against.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="TestMongoDataStoreConnectionStringFactory"/> as the
+	/// <see cref="IMongoDataStoreConnectionStringFactory"/>.
 	/// </summary>
 	public class TestMongoModule : MongoModule
 	{

--- a/Framework/Ninject/Cqrs.Ninject.Mongo/Cqrs.Ninject.Mongo.csproj
+++ b/Framework/Ninject/Cqrs.Ninject.Mongo/Cqrs.Ninject.Mongo.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.Mongo.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,8 +34,13 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.Mongo.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="cdmdotnet.StateManagement, Version=3.0.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\cdmdotnet.StateManagement.3.0.13.9\lib\net40\cdmdotnet.StateManagement.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Ninject.3.2.2.0\lib\net40\Ninject.dll</HintPath>
     </Reference>

--- a/Framework/Ninject/Cqrs.Ninject.Mongo/TestMongoDataStoreConnectionStringFactory.cs
+++ b/Framework/Ninject/Cqrs.Ninject.Mongo/TestMongoDataStoreConnectionStringFactory.cs
@@ -7,34 +7,54 @@
 #endregion
 
 using System.Configuration;
-using System.Runtime.Remoting.Messaging;
+using cdmdotnet.StateManagement;
+using cdmdotnet.StateManagement.Threaded;
 using Cqrs.Mongo.Factories;
 
 namespace Cqrs.Ninject.Mongo
 {
+	/// <summary>
+	/// A <see cref="IMongoDataStoreConnectionStringFactory"/>
+	/// that enables you to set a database name with <see cref="DatabaseName"/>. This means you can randomly generate your own database name per test.
+	/// </summary>
 	public class TestMongoDataStoreConnectionStringFactory : IMongoDataStoreConnectionStringFactory
 	{
 		private const string MongoDbConnectionStringKey = "MongoDb-Test";
 
 		private const string CallContextDatabaseNameKey = "MongoDataStoreConnectionStringFactory¿DatabaseName";
 
+		private static IContextItemCollection Query { get; set; }
+
+		static TestMongoDataStoreConnectionStringFactory()
+		{
+			Query = new ThreadedContextItemCollection();
+		}
+
+		/// <summary>
+		/// The name of the database currently being used.
+		/// </summary>
 		public static string DatabaseName
 		{
 			get
 			{
-				return (string)CallContext.GetData(CallContextDatabaseNameKey);
+				return Query.GetData<string>(CallContextDatabaseNameKey);
 			}
 			set
 			{
-				CallContext.SetData(CallContextDatabaseNameKey, value);
+				Query.SetData(CallContextDatabaseNameKey, value);
 			}
 		}
-
+		/// <summary>
+		/// Gets the current connection string.
+		/// </summary>
 		public string GetMongoConnectionString()
 		{
 			return ConfigurationManager.ConnectionStrings[MongoDbConnectionStringKey].ConnectionString;
 		}
 
+		/// <summary>
+		/// Gets the value of <see cref="DatabaseName"/>.
+		/// </summary>
 		public string GetMongoDatabaseName()
 		{
 			return DatabaseName;

--- a/Framework/Ninject/Cqrs.Ninject.Mongo/packages.config
+++ b/Framework/Ninject/Cqrs.Ninject.Mongo/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="cdmdotnet.StateManagement" version="3.0.13.9" targetFramework="net40" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net40" />
 </packages>

--- a/Framework/Ninject/Cqrs.Ninject.MongoDB/Configuration/MongoDbDataStoreModule.cs
+++ b/Framework/Ninject/Cqrs.Ninject.MongoDB/Configuration/MongoDbDataStoreModule.cs
@@ -11,6 +11,9 @@ using Ninject.Modules;
 
 namespace Cqrs.Ninject.MongoDB.Configuration
 {
+	/// <summary>
+	/// A <see cref="INinjectModule"/> that wires up <see cref="MongoDbDataStoreConnectionStringFactory"/> as the <see cref="IMongoDbDataStoreConnectionStringFactory"/>.
+	/// </summary>
 	public class MongoDbDataStoreModule : NinjectModule
 	{
 		#region Overrides of NinjectModule

--- a/Framework/Ninject/Cqrs.Ninject.MongoDB/Configuration/MongoDbEventStoreModule.cs
+++ b/Framework/Ninject/Cqrs.Ninject.MongoDB/Configuration/MongoDbEventStoreModule.cs
@@ -6,6 +6,7 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using System;
 using Cqrs.Events;
 using Cqrs.MongoDB.Events;
 using Cqrs.MongoDB.Serialisers;
@@ -13,6 +14,10 @@ using Ninject.Modules;
 
 namespace Cqrs.Ninject.MongoDB.Configuration
 {
+	/// <summary>
+	/// A <see cref="INinjectModule"/> that wires up <see cref="MongoDbEventStore{TAuthenticationToken}"/> as the <see cref="IEventStore{TAuthenticationToken}"/>.
+	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	public class MongoDbEventStoreModule<TAuthenticationToken> : NinjectModule
 	{
 		#region Overrides of NinjectModule

--- a/Framework/Ninject/Cqrs.Ninject.MongoDB/Configuration/TestMongoDbModule.cs
+++ b/Framework/Ninject/Cqrs.Ninject.MongoDB/Configuration/TestMongoDbModule.cs
@@ -6,15 +6,18 @@
 // // -----------------------------------------------------------------------
 #endregion
 
+using System;
 using Cqrs.MongoDB.Events;
 using Cqrs.MongoDB.Factories;
+using Ninject.Modules;
 
 namespace Cqrs.Ninject.MongoDB.Configuration
 {
 	/// <summary>
-	/// A <see cref="MongoDbDataStoreModule"/> that assumes the connection string is keyed "MongoDb-Test".
-	/// This will generated a random suffix to the database name so as to create a unique store for testing against.
+	/// A <see cref="INinjectModule"/> that wires up <see cref="TestMongoDbDataStoreConnectionStringFactory"/> as the
+	/// <see cref="IMongoDbEventStoreConnectionStringFactory"/> and <see cref="IMongoDbDataStoreConnectionStringFactory"/>.
 	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	public class TestMongoDbDataStoreModule<TAuthenticationToken> : MongoDbEventStoreModule<TAuthenticationToken>
 	{
 		/// <summary>

--- a/Framework/Ninject/Cqrs.Ninject.MongoDB/Cqrs.Ninject.MongoDB.csproj
+++ b/Framework/Ninject/Cqrs.Ninject.MongoDB/Cqrs.Ninject.MongoDB.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.MongoDB.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,8 +33,13 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.MongoDB.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="cdmdotnet.StateManagement, Version=3.0.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\cdmdotnet.StateManagement.3.0.13.9\lib\net40\cdmdotnet.StateManagement.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
       <Private>True</Private>

--- a/Framework/Ninject/Cqrs.Ninject.MongoDB/packages.config
+++ b/Framework/Ninject/Cqrs.Ninject.MongoDB/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="cdmdotnet.StateManagement" version="3.0.13.9" targetFramework="net45" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net45" />
 </packages>

--- a/Framework/Ninject/Cqrs.Ninject.WebApi/Configuration/SimplifiedNinjectWebApi.cs
+++ b/Framework/Ninject/Cqrs.Ninject.WebApi/Configuration/SimplifiedNinjectWebApi.cs
@@ -14,16 +14,21 @@ using Ninject;
 using Ninject.Web.Common;
 
 [assembly: WebActivatorEx.PreApplicationStartMethod(typeof(Cqrs.Ninject.WebApi.Configuration.SimplifiedNinjectWebApi), "Start", Order = 50)]
-[assembly: WebActivatorEx.ApplicationShutdownMethodAttribute(typeof(Cqrs.Ninject.WebApi.Configuration.SimplifiedNinjectWebApi), "Stop", Order = 50)]
+[assembly: WebActivatorEx.ApplicationShutdownMethod(typeof(Cqrs.Ninject.WebApi.Configuration.SimplifiedNinjectWebApi), "Stop", Order = 50)]
 
 namespace Cqrs.Ninject.WebApi.Configuration
 {
+	/// <summary>
+	/// A <see cref="WebActivatorEx.PreApplicationStartMethodAttribute"/> that calls <see cref="Start"/>
+	/// and <see cref="WebActivatorEx.ApplicationShutdownMethodAttribute"/> that calls <see cref="Stop"/>
+	/// configuring Simplified SQL by wiring up <see cref="SimplifiedSqlModule{TAuthenticationToken}"/>.
+	/// </summary>
 	public static class SimplifiedNinjectWebApi
 	{
 		private static readonly Bootstrapper Bootstrapper = new Bootstrapper();
 
 		/// <summary>
-		/// Starts the application
+		/// Starts the application.
 		/// </summary>
 		public static void Start()
 		{
@@ -41,7 +46,7 @@ namespace Cqrs.Ninject.WebApi.Configuration
 		}
 
 		/// <summary>
-		/// Creates the kernel that will manage your application.
+		/// Creates the kernel that will manage your application by instantiating a new instance of <see cref="WebApiStartUp"/>.
 		/// </summary>
 		/// <returns>The created kernel.</returns>
 		private static IKernel CreateKernel()

--- a/Framework/Ninject/Cqrs.Ninject.WebApi/Cqrs.Ninject.WebApi.csproj
+++ b/Framework/Ninject/Cqrs.Ninject.WebApi/Cqrs.Ninject.WebApi.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.WebApi.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.WebApi.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Framework/Ninject/Cqrs.Ninject/Configuration/CqrsModule.cs
+++ b/Framework/Ninject/Cqrs.Ninject/Configuration/CqrsModule.cs
@@ -25,17 +25,26 @@ using Ninject.Modules;
 namespace Cqrs.Ninject.Configuration
 {
 	/// <summary>
-	/// The <see cref="INinjectModule"/> for use with the Cqrs package.
+	/// The main <see cref="INinjectModule"/> for use with the CQRS package that wires up many of the prerequisites for running CQRS.NET.
 	/// </summary>
 	/// <typeparam name="TAuthenticationToken">The <see cref="Type"/> of the authentication token.</typeparam>
 	/// <typeparam name="TAuthenticationTokenHelper">The <see cref="Type"/> of the authentication token helper.</typeparam>
 	public class CqrsModule<TAuthenticationToken, TAuthenticationTokenHelper> : ResolvableModule
 		where TAuthenticationTokenHelper : class, IAuthenticationTokenHelper<TAuthenticationToken>
 	{
+		/// <summary>
+		/// Indicates that web based wire-up is required rather than console, WPF or winforms based wire-up.s
+		/// </summary>
 		protected bool SetupForWeb { get; private set; }
 
+		/// <summary>
+		/// Indicates that logging should be configured for SQL Server rather than console.
+		/// </summary>
 		protected bool SetupForSqlLogging { get; private set; }
 
+		/// <summary>
+		/// Indicates that the <see cref="ConfigurationManager"/> should be registered automatically.
+		/// </summary>
 		protected bool RegisterDefaultConfigurationManager { get; private set; }
 
 		/// <summary>
@@ -224,9 +233,11 @@ namespace Cqrs.Ninject.Configuration
 			Bind<IAggregateRepository<TAuthenticationToken>>()
 				.To<AggregateRepository<TAuthenticationToken>>()
 				.InSingletonScope();
+#pragma warning disable 618
 			Bind<IRepository<TAuthenticationToken>>()
 				.To<Repository<TAuthenticationToken>>()
 				.InSingletonScope();
+#pragma warning restore 618
 			Bind<ISagaRepository<TAuthenticationToken>>()
 				.To<SagaRepository<TAuthenticationToken>>()
 				.InSingletonScope();

--- a/Framework/Ninject/Cqrs.Ninject/Configuration/InProcessCommandBusModule.cs
+++ b/Framework/Ninject/Cqrs.Ninject/Configuration/InProcessCommandBusModule.cs
@@ -49,10 +49,12 @@ namespace Cqrs.Ninject.Configuration
 		{
 		}
 
+#pragma warning disable 618
 		/// <summary>
 		/// Register the <see cref="ICommandPublisher{TAuthenticationToken}"/>, <see cref="IPublishAndWaitCommandPublisher{TAuthenticationToken}"/>, <see cref="ICommandReceiver{TAuthenticationToken}"/> and <see cref="ICommandHandlerRegistrar"/>
 		/// Register (for backwards compatibility) <see cref="ICommandSender{TAuthenticationToken}"/>
 		/// </summary>
+#pragma warning restore 618
 		public virtual void RegisterCqrsRequirements()
 		{
 			bool isInProcessBusBound = Kernel.GetBindings(typeof(InProcessBus<TAuthenticationToken>)).Any();
@@ -67,9 +69,11 @@ namespace Cqrs.Ninject.Configuration
 			else
 				inProcessBus = Kernel.Get<InProcessBus<TAuthenticationToken>>();
 
+#pragma warning disable 618
 			Bind<ICommandSender<TAuthenticationToken>>()
 				.ToConstant(inProcessBus)
 				.InSingletonScope();
+#pragma warning restore 618
 
 			Bind<ICommandPublisher<TAuthenticationToken>>()
 				.ToConstant(inProcessBus)

--- a/Framework/Ninject/Cqrs.Ninject/Configuration/NinjectDependencyResolver.cs
+++ b/Framework/Ninject/Cqrs.Ninject/Configuration/NinjectDependencyResolver.cs
@@ -33,20 +33,22 @@ namespace Cqrs.Ninject.Configuration
 		public static IList<INinjectModule> ModulesToLoad = new List<INinjectModule>();
 
 		/// <summary>
-		/// A user supplied <see cref="Func{TResult}"/> that will be called during <see cref="Start"/> to create and populate <see cref="Current"/>.
+		/// A user supplied <see cref="Func{TResult}"/> that will be called during <see cref="Start"/> to create and populate <see cref="DependencyResolver.Current"/>.
 		/// </summary>
 		public static Func<IKernel, NinjectDependencyResolver> DependencyResolverCreator { get; set; }
 
 		/// <summary>
 		/// Instantiates a new instance of <see cref="NinjectDependencyResolver"/>
 		/// </summary>
-		/// <param name="kernel"></param>
 		public NinjectDependencyResolver(IKernel kernel)
 		{
 			Kernel = kernel;
 			BindDependencyResolver();
 		}
 
+		/// <summary>
+		/// Checks if <see cref="IDependencyResolver"/> has already been registered and if not, registers this instance to it.
+		/// </summary>
 		protected virtual void BindDependencyResolver()
 		{
 			bool isDependencyResolverBound = Kernel.GetBindings(typeof(IDependencyResolver)).Any();

--- a/Framework/Ninject/Cqrs.Ninject/Configuration/ResolvableModule.cs
+++ b/Framework/Ninject/Cqrs.Ninject/Configuration/ResolvableModule.cs
@@ -18,14 +18,24 @@ namespace Cqrs.Ninject.Configuration
 	/// </summary>
 	public abstract class ResolvableModule : NinjectModule
 	{
+		/// <summary>
+		/// Resolves instances for the specified <typeparamref name="T"/>.
+		/// </summary>
+		/// <typeparam name="T">The <see cref="Type"/> to resolve.</typeparam>
+		/// <returns>Null if no resolution is made.</returns>
 		protected virtual T Resolve<T>()
 		{
 			return (T)Resolve(typeof(T));
 		}
 
-		protected virtual object Resolve(Type serviceType)
+		/// <summary>
+		/// Resolves instances for the specified <paramref name="type"/>.
+		/// </summary>
+		/// <param name="type">The <see cref="Type"/> to resolve.</param>
+		/// <returns>Null if no resolution is made.</returns>
+		protected virtual object Resolve(Type type)
 		{
-			return Kernel.Resolve(Kernel.CreateRequest(serviceType, null, new Parameter[0], true, true)).SingleOrDefault();
+			return Kernel.Resolve(Kernel.CreateRequest(type, null, new Parameter[0], true, true)).SingleOrDefault();
 		}
 	}
 }

--- a/Framework/Ninject/Cqrs.Ninject/Configuration/SimplifiedNinjectStartUp.cs
+++ b/Framework/Ninject/Cqrs.Ninject/Configuration/SimplifiedNinjectStartUp.cs
@@ -21,11 +21,18 @@ namespace Cqrs.Ninject.Configuration
 	public class SimplifiedNinjectStartUp<THostModule>
 		where THostModule : INinjectModule, new()
 	{
+		/// <summary>
+		/// Instantiates a new instance of <see cref="SimplifiedNinjectStartUp{THostModule}"/>
+		/// </summary>
 		public SimplifiedNinjectStartUp(IConfigurationManager configurationManager)
 		{
 			ConfigurationManager = configurationManager;
 		}
 
+		/// <summary>
+		/// The <see cref="IConfigurationManager"/> that will be used to resolve configuration settings in <see cref="CreateKernel"/>.
+		/// It is not used elsewhere.
+		/// </summary>
 		protected IConfigurationManager ConfigurationManager { get; private set; }
 
 		/// <summary>

--- a/Framework/Ninject/Cqrs.Ninject/Cqrs.Ninject.csproj
+++ b/Framework/Ninject/Cqrs.Ninject/Cqrs.Ninject.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cqrs.Ninject.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cqrs.Ninject.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="cdmdotnet.AutoMapper, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">


### PR DESCRIPTION
* Deprecated all CommandBus named classes for CommandHub in Ninject packages/projects.
* Deprecated all EventBus named classes for EventHub in Ninject packages/projects.
* Set all Ninject packages/projects to throw a compiler error if any warnings (including missing XML commenting) occurs.